### PR TITLE
Added an option to open the link in same window

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -17,7 +17,8 @@
         bigSize: 500,
         gaTrack  : true,
         gaLabel  : '#1 Stegosaurus',
-        autoAnimate: true
+        autoAnimate: true,
+        openInNewWindow: false
       });
     });
   </script>

--- a/jquery.peelback.js
+++ b/jquery.peelback.js
@@ -57,7 +57,7 @@
       bigMaskSize = Math.floor((base.settings.bigSize * 0.96)) + 'px';
       
       //Assemble
-      peelHTML = $('<div id="peelback"><a href="' + base.settings.clickURL + '" target="_blank"><img src="' + base.settings.peelImage +'" alt="" border="0" /></a><div></div></div>');
+      peelHTML = $('<div id="peelback"><a href="' + base.settings.clickURL + '"' + (base.settings.openInNewWindow ? ' target="_blank"' : '') + '><img src="' + base.settings.peelImage +'" alt="" border="0" /></a><div></div></div>');
       peelImage = peelHTML.find('img');
       peelMask = peelHTML.find('div');
           
@@ -150,15 +150,16 @@
   };
     
   $.Peelback.defaultSettings = {
-    adImage     : null,
-    peelImage   : null,
-    clickURL    : null,
-    smallSize   : 58,
-    bigSize     : 510,
-    gaTrack     : false,
-    gaLabel     : 'default',
-    autoAnimate : true,
-    debug       : false
+    adImage         : null,
+    peelImage       : null,
+    clickURL        : null,
+    smallSize       : 58,
+    bigSize         : 510,
+    gaTrack         : false,
+    gaLabel         : 'default',
+    autoAnimate     : true,
+    debug           : false,
+    openInNewWindow : true
   };
   
   $.fn.peelback = function(settings) {

--- a/readme.md
+++ b/readme.md
@@ -23,18 +23,20 @@ Just call the `.peelback()` method on the `body` element and fill in the paramet
 **`gaLabel`** : GA event label to use (string; default="default")  
 **`autoAnimate`** : animate peelback corner on pageload (boolean; default=true)   
 **`debug`** : display errors in console (boolean; default=false) 
+**`openInNewWindow`** : specifies whether link should be opened in a new window (boolean; default=true) 
     
     $(function(){
       $('body').peelback({
-        adImage     : 'peel-ad.png',
-        peelImage   : '../assets/peel-image.png',
-        clickURL    : 'http://www.thebestdinosaur.com/',
-        smallSize   : 50,
-        bigSize     : 500,
-        gaTrack     : true,
-        gaLabel     : '#1 Stegosaurus',
-        autoAnimate : true,
-        debug       : false 
+        adImage         : 'peel-ad.png',
+        peelImage       : '../assets/peel-image.png',
+        clickURL        : 'http://www.thebestdinosaur.com/',
+        smallSize       : 50,
+        bigSize         : 500,
+        gaTrack         : true,
+        gaLabel         : '#1 Stegosaurus',
+        autoAnimate     : true,
+        debug           : false 
+        openInNewWindow : false 
       });
     });
     


### PR DESCRIPTION
I get that this is largely supposed to be used for advertising, but I recently wanted to use this to change a background on a web page and create a peelback illusion. This meant I didn't want it opening in a new window.

I've made a very quick change to make this optional, but have defaulted it to set the target to "_blank" for backward compatibility.
